### PR TITLE
APRs for flywheel rewards

### DIFF
--- a/contracts/external/compound/ICToken.sol
+++ b/contracts/external/compound/ICToken.sol
@@ -45,6 +45,8 @@ interface ICToken {
 
   function borrowBalanceStored(address account) external view returns (uint256);
 
+  function exchangeRateCurrent() external view returns (uint256);
+
   function exchangeRateStored() external view returns (uint256);
 
   function getCash() external view returns (uint256);

--- a/contracts/flywheel/FlywheelCore.sol
+++ b/contracts/flywheel/FlywheelCore.sol
@@ -14,7 +14,7 @@ import { IFlywheelBooster } from "./interfaces/IFlywheelBooster.sol";
  @notice Flywheel is a general framework for managing token incentives.
          It takes reward streams to various *strategies* such as staking LP tokens and divides them among *users* of those strategies.
 
-         The Core contract maintaings three important pieces of state:
+         The Core contract maintains three important pieces of state:
          * the rewards index which determines how many rewards are owed per token per strategy. User indexes track how far behind the strategy they are to lazily calculate all catch-up rewards.
          * the accrued (unclaimed) rewards per user.
          * references to the booster and rewards module described below.


### PR DESCRIPTION
## Description

Ported from https://github.com/fei-protocol/fuse-flywheel/blob/0bfaebaf99043871d5c35e6e03ff123615b2df98/src/FuseFlywheelLensRouter.sol

Use in the UI like this

```
    const lens = createFlywheelLens(provider)
    let result: MarketRewardInfo[] = await lens.callStatic.getMarketRewardsInfo(comptroller)
    let cTokenPluginRewardsMap: CTokenPluginRewardsMap = {}
    let flywheelCTokensMap: FlywheelCTokensMap = {}
    let uniqueRewardTokens: Set<string> = new Set<string>()

    if (result) {
      result.forEach(marketRewardInfo => {
        const { market, rewardsInfo } = marketRewardInfo

        rewardsInfo.forEach(flywheelData => {
          const { flywheel, formattedAPR, rewardToken } = filterOnlyObjectProperties(flywheelData)
          const obj = {
            rewardToken,
            formattedAPR: parseFloat(formattedAPR.toString()) / 1e16,
          }

          if (!formattedAPR.isZero()) {
            uniqueRewardTokens.add(rewardToken)
            // flywheelCTokensMap[flywheel] = [...flywheelCTokensMap[flywheel], market]
            cTokenPluginRewardsMap[market] = {
              ...cTokenPluginRewardsMap[market],
              [flywheel]: obj
            }
          }
        })
      })
    }

```
## Related Issue(s)

#133 