### PR TITLE
fixing the second reentrancy vulnerability in the CToken

### DIFF
--- a/contracts/compound/CToken.sol
+++ b/contracts/compound/CToken.sol
@@ -887,6 +887,11 @@ contract CToken is CTokenInterface, Exponential, TokenErrorReporter {
     // EFFECTS & INTERACTIONS
     // (No safe failures beyond this point)
 
+    /* We write the previously calculated values into storage */
+    accountBorrows[borrower].principal = vars.accountBorrowsNew;
+    accountBorrows[borrower].interestIndex = borrowIndex;
+    totalBorrows = vars.totalBorrowsNew;
+
     /*
      * We invoke doTransferOut for the borrower and the borrowAmount.
      *  Note: The cToken must handle variations between ERC-20 and ETH underlying.
@@ -894,11 +899,6 @@ contract CToken is CTokenInterface, Exponential, TokenErrorReporter {
      *  doTransferOut reverts if anything goes wrong, since we can't be sure if side effects occurred.
      */
     doTransferOut(borrower, borrowAmount);
-
-    /* We write the previously calculated values into storage */
-    accountBorrows[borrower].principal = vars.accountBorrowsNew;
-    accountBorrows[borrower].interestIndex = borrowIndex;
-    totalBorrows = vars.totalBorrowsNew;
 
     /* We emit a Borrow event */
     emit Borrow(borrower, borrowAmount, vars.accountBorrowsNew, vars.totalBorrowsNew);


### PR DESCRIPTION
## Description

The other case where changes to the state need to be made before calling the external transfer