### PR TITLE
transfer all BeefyErc4626 shares to the deployer

### DIFF
--- a/contracts/compound/CErc20PluginDelegate.sol
+++ b/contracts/compound/CErc20PluginDelegate.sol
@@ -32,21 +32,6 @@ contract CErc20PluginDelegate is CErc20Delegate {
 
     require(_plugin != address(0), "0");
 
-    if (address(plugin) == 0x0b96dccbAA03447Fd5f5Fd733e0ebD10680E84c1 && totalSupply > 0) {
-      // the two larges holders
-      _burnAll(0x0D8e060CA2D847553ec14394ee6B304623E0d1d6);
-      _burnAll(0x49707808908f0C2450B3F2672E012eDBf49eD808);
-
-      // burn dust leftover
-      _burnAll(0x55452c8Ffa2434bf5E738D752C5581B409E6633D);
-      _burnAll(0xa13c2DEF62c36697407fBe7d574e946bf60d7350);
-      _burnAll(0xc43e5C94f0fCf442Db226aB78F4985607d366052);
-      _burnAll(0x75C1D99B8C39Dd31b6815A6269Dc7B16D43a11c1);
-      _burnAll(0x489CAF6518c28804E31CaE58a1429341D739b73f);
-
-      totalSupply = 0;
-    }
-
     if (address(plugin) != address(0) && plugin.balanceOf(address(this)) != 0) {
       plugin.redeem(plugin.balanceOf(address(this)), address(this), address(this));
     }
@@ -59,11 +44,6 @@ contract CErc20PluginDelegate is CErc20Delegate {
     if (amount != 0) {
       deposit(amount);
     }
-  }
-
-  function _burnAll(address from) private {
-    emit Transfer(from, address(0), accountTokens[from]);
-    accountTokens[from] = 0;
   }
 
   /*** CToken Overrides ***/

--- a/contracts/compound/CErc20PluginRewardsDelegate.sol
+++ b/contracts/compound/CErc20PluginRewardsDelegate.sol
@@ -8,27 +8,6 @@ contract CErc20PluginRewardsDelegate is CErc20PluginDelegate {
   /// to be overriden for use cases where rewardToken needs to be pulled in
   function claim() external {}
 
-  function _becomeImplementation(bytes calldata data) external virtual override {
-    require(msg.sender == address(this) || hasAdminRights());
-
-    address _plugin = abi.decode(data, (address));
-
-    require(_plugin != address(0), "0");
-
-    if (address(plugin) != address(0) && plugin.balanceOf(address(this)) != 0) {
-      plugin.redeem(plugin.balanceOf(address(this)), address(this), address(this));
-    }
-
-    plugin = IERC4626(_plugin);
-
-    EIP20Interface(underlying).approve(_plugin, type(uint256).max);
-
-    uint256 amount = EIP20Interface(underlying).balanceOf(address(this));
-    if (amount != 0) {
-      deposit(amount);
-    }
-  }
-
   /// @notice token approval function
   function approve(address _token, address _spender) external {
     require(hasAdminRights(), "!admin");


### PR DESCRIPTION
On the withdrawal from the beefy vault, only up to 8% will be recovered.

The only way to influence the rate of redeeming/withdrawing from the beefy vault is to upgrade the strategy in it with such that makes the balance() call return 20x less than the current - then we will be able to redeem from our Erc4626 at such rate that will extract assets from it, instead of locking them there.

For that to happen, Beefy need tell all the 564 holders to withdraw from this vault (probably depositing to another that is just the same), then they need to transfer the ownership of the vault to us, so we can replace the strategy with a hacked one, that consumes almost all the deposits of Cake-LP and returns 0 or close to 0 for the balanceOf() call. Then we can call the redeem() function of the Erc4626 vault with a low shares value that is calculated at a very high rate and will transfer to us all the Cake-LP in the Erc4626.
Current Beefy Vault holders:
https://bscscan.com/token/0x94e85b8e050f3f281cb9597cc0144f1f7af1fe9b#balances